### PR TITLE
fix: add console request check to EVENT_BEFORE_SEND handler

### DIFF
--- a/src/MagicLogin.php
+++ b/src/MagicLogin.php
@@ -153,6 +153,11 @@ class MagicLogin extends Plugin
             Mailer::class,
             Mailer::EVENT_BEFORE_SEND,
             function (MailEvent $event) {
+                // Skip for console requests (e.g. queue jobs) — getBodyParam() is not available
+                if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+                    return;
+                }
+
                 if (! $this->request->getBodyParam('magicLoginRegistration')) {
                     return false;
                 }


### PR DESCRIPTION
## Summary
- Adds a console request check in the `Mailer::EVENT_BEFORE_SEND` handler to skip `getBodyParam()` calls in CLI/queue context

## Problem
The `EVENT_BEFORE_SEND` handler at `MagicLogin.php:156` calls `$this->request->getBodyParam('magicLoginRegistration')` on every email sent. When emails are sent from queue jobs (e.g., Formie notifications), the request is `craft\console\Request` which doesn't have `getBodyParam()`, causing:

```
yii\base\UnknownMethodException: Calling unknown method: craft\console\Request::getBodyParam()
```

This breaks all queued email notifications from any plugin (Formie, etc).

## Fix
Added a `getIsConsoleRequest()` check before calling `getBodyParam()`. In console context the handler returns early — the magic login registration check is only relevant during web requests anyway.

Fixes #44