### PR TITLE
fix: avoid session flash during console install

### DIFF
--- a/src/MagicLogin.php
+++ b/src/MagicLogin.php
@@ -340,6 +340,17 @@ class MagicLogin extends Plugin
 
         // TODO: This will need removing once the check for beforeInstall can pass.
         if (Craft::$app->getEdition() !== CmsEdition::Pro) {
+            if (Craft::$app->getRequest()->getIsConsoleRequest()) {
+                Craft::warning(
+                    Craft::t(
+                        'magic-login',
+                        'For this plugin to function correctly, you must have a pro license for Craft.'
+                    ),
+                    __METHOD__
+                );
+                return;
+            }
+
             Craft::$app->session->setError(
                 Craft::t(
                     'magic-login',


### PR DESCRIPTION
## Summary
- avoid starting a web session from the plugin install handler during console installs
- log the Pro edition requirement as a warning for console requests while keeping the existing CP flash for web requests

## Context
When Craft installs plugins from project config in a console command, migration output may already have been sent before `EVENT_AFTER_INSTALL_PLUGIN` fires. Calling `Craft::$app->session->setError()` in that path can trigger `session_name(): Session name cannot be changed after headers have already been sent` and abort installation.
